### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ docker run -it --rm --gpus all -v /path/to/audio_files:/app -v /path/to/cache:/r
 You can either use the pre-built images from Docker Hub, or build the images yourself.
 
 ```
-docker build -f Dockerfile.cpu -t whisperx:cpu
-docker build -f Dockerfile.cuda118 -t whisperx:cuda118
+docker build -f Dockerfile.cpu -t whisperx:cpu .
+docker build -f Dockerfile.cuda118 -t whisperx:cuda118 .
 ```


### PR DESCRIPTION
Thanks for creating these images.   A quick PR to add missing dots `.` to the end of docker build commands. Required to set build context to the current directory.

Ubuntu without the `.` gives cryptic output errors
```
docker build --file Dockerfile.cuda118 -t whisperx:cuda118
ERROR: "docker buildx build" requires exactly 1 argument.
See 'docker buildx build --help'.

Usage:  docker buildx build [OPTIONS] PATH | URL | -
```